### PR TITLE
New delegates for slicing events

### DIFF
--- a/Plugins/Slicing/Source/SlicingLogic/Private/SlicingHelper.cpp
+++ b/Plugins/Slicing/Source/SlicingLogic/Private/SlicingHelper.cpp
@@ -37,7 +37,7 @@ UProceduralMeshComponent* FSlicingHelper::ConvertStaticToProceduralMeshComponent
 	return ProceduralMeshComponent;
 }
 
-void FSlicingHelper::ConvertProceduralComponentToStaticMeshActor(
+AStaticMeshActor* FSlicingHelper::ConvertProceduralComponentToStaticMeshActor(
 	UProceduralMeshComponent* ProceduralMeshComponent, TArray<FStaticMaterial> &StaticMaterials)
 {
 	// Generate the static mesh from the data scanned from the procedural mesh
@@ -63,6 +63,8 @@ void FSlicingHelper::ConvertProceduralComponentToStaticMeshActor(
 	
 	// Remove the old component
 	ProceduralMeshComponent->DestroyComponent();
+
+	return StaticMeshActor;
 }
 
 template<class ComponentType>

--- a/Plugins/Slicing/Source/SlicingLogic/Public/SlicingBladeComponent.h
+++ b/Plugins/Slicing/Source/SlicingLogic/Public/SlicingBladeComponent.h
@@ -12,9 +12,25 @@ class UPhysicsConstraintComponent;
 /**
 * The delegates for events regarding the cutting-process
 */
-DECLARE_DYNAMIC_MULTICAST_DELEGATE_FourParams(FBeginSlicingSignature, USlicingBladeComponent*, SlicingBladeComponent, AActor*, CuttingObject, AActor*, CutObject, FDateTime, BroadcastTime);
-DECLARE_DYNAMIC_MULTICAST_DELEGATE_FourParams(FEndSlicingSignature, USlicingBladeComponent*, SlicingBladeComponent, AActor*, CuttingObject, AActor*, CutObject, FDateTime, BroadcastTime);
+DECLARE_MULTICAST_DELEGATE_FourParams(	FBeginSlicingSignature, UObject* /*CuttingAgent*/,
+																UObject* /*CuttingObject*/,
+																UObject* /*CutObject*/, 
+																float /*Time*/);
 
+DECLARE_MULTICAST_DELEGATE_ThreeParams(	FEndSlicingOnFailSignature,	UObject* /*CuttingAgent*/,
+																	UObject* /*CutObject*/, 
+																	float /*Time*/);
+
+DECLARE_MULTICAST_DELEGATE_FourParams(FEndSlicingOnSuccessSignature,	UObject* /*CuttingAgent*/,
+																		UObject* /*CutObject*/,
+																		UObject* /*outputsCreated*/,
+																		float /*Time*/);
+
+DECLARE_MULTICAST_DELEGATE_TwoParams(FObjectDestruction, UObject* /*ObjectActedOn*/, float /*Time*/);
+
+DECLARE_MULTICAST_DELEGATE_ThreeParams(FObjectCreation,		UObject* /*TransformedObject*/,
+															UObject* /*NewSlice*/,
+															float /*Time*/);
 
 UCLASS()
 class SLICINGLOGIC_API USlicingBladeComponent: public USlicingComponent
@@ -22,10 +38,11 @@ class SLICINGLOGIC_API USlicingBladeComponent: public USlicingComponent
 	GENERATED_BODY()
 
 public:
-	UPROPERTY()
 	FBeginSlicingSignature OnBeginSlicing;
-	UPROPERTY()
-	FEndSlicingSignature OnEndSlicing;
+	FEndSlicingOnFailSignature OnEndSlicingFail;
+	FEndSlicingOnSuccessSignature OnEndSlicingSuccess;
+	FObjectDestruction OnObjectDestruction;
+	FObjectCreation OnObjectCreation;
 
 public:
 	// Sets default values. Called when generated, even in the editor.

--- a/Plugins/Slicing/Source/SlicingLogic/Public/SlicingHelper.h
+++ b/Plugins/Slicing/Source/SlicingLogic/Public/SlicingHelper.h
@@ -29,7 +29,7 @@ public:
 	* @param ProceduralMeshComponent - The procedural mesh component that will be used to create the static mesh
 	* @param StaticMaterials - The old static materials used to properly recreate the static mesh
 	*/
-	static void ConvertProceduralComponentToStaticMeshActor(
+	static AStaticMeshActor* ConvertProceduralComponentToStaticMeshActor(
 		UProceduralMeshComponent* ProceduralMeshComponent, TArray<FStaticMaterial> &StaticMaterials
 	);
 


### PR DESCRIPTION
New delegates for failed attempts and successful slicing, as well for the creation of new objects (new Slice and "new" original) and "destruction" of original object. 